### PR TITLE
Fixed failing tests when using uppercase chars

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,12 +9,12 @@ var noop = require('noop3');
 function is(x) {
     // this line calls the noop function
     noop();
-    
+
     var thirteenStrings = [
         1101, // Binary 13
         "https://scontent.cdninstagram.com/hphotos-xtf1/t51.2885-15/s320x320/e35/12237511_444845689040315_1101385461_n.jpg", // Just because we can
-        "Rem Hadley", // And because he's 13
-        
+        "rem hadley", // And because he's 13
+
         // Languages
         "thirteen", // English
         "тринадцать" // Russia

--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ function is(x) {
         "тринадцать" // Russia
     ]
 
-    if (thirteenStrings.indexOf(x) > -1) {
+    if (thirteenStrings.indexOf(x.toLowerCase()) > -1) {
         x = 13;
     }
 


### PR DESCRIPTION
This started failing in #34, because of the new syntax.