### PR TITLE
Fix typo in language name

### DIFF
--- a/index.js
+++ b/index.js
@@ -57,7 +57,7 @@ function is(x) {
         "tiga belas", // Malay
         "арван", // Mongolian
         "trzynaście", // Polish
-        "treze", // Portoguese
+        "treze", // Portuguese
         "ਤੀਹ", // Punjabi
         "treisprezece", // Romanian
         "тринадцать", // Russia


### PR DESCRIPTION
Fixing "Portuguese" from "Portoguese"