### PR TITLE
Support nonorthogonal Yiddish

### DIFF
--- a/index.js
+++ b/index.js
@@ -73,6 +73,7 @@ function is(x) {
         "تیرہ", // Urdu
         "tri ar ddeg", // Welsh
         "דרייַצן", // Yiddish,
+        "דרייצן", // Yiddish (without diacritics),
         "kumi na tatu", // Swahili
 
         //Imaginary 13's

--- a/test.js
+++ b/test.js
@@ -66,4 +66,5 @@ tap.equal(is("тринадцять").thirteen(), true); // Ukrainian
 tap.equal(is("تیرہ").thirteen(), true); // Urdu
 tap.equal(is("tri ar ddeg").thirteen(), true); // Welsh
 tap.equal(is("דרייַצן").thirteen(), true); // Yiddish
+tap.equal(is("דרייצן").thirteen(), true); // Yiddish (without diacritics),
 tap.equal(is("kumi na tatu").thirteen(), true); // Swahili


### PR DESCRIPTION
In modern Yiddish the "niqqud" (diacritical marks) are optional (ref http://blogs.yiddish.forward.com/yiddish-with-an-aleph/)

We shouldn't miss this vital opportunity to catch a 13.