### PR TITLE
update language translations

### DIFF
--- a/index.js
+++ b/index.js
@@ -85,6 +85,9 @@ function is(x) {
         "דרייַצן", // Yiddish,
         "דרייצן", // Yiddish (without diacritics),
         "kumi na tatu", // Swahili
+        "mẹtala", // Yoruba
+        "iri na atọ", // Igbo
+        "goma sha uku", // Hausa
 
         // Thirteen pronunciation
         "θərˈtiːn"


### PR DESCRIPTION
Include three local language translations of the word thirteen from Nigeria