### PR TITLE
Fixed wrong require in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ npm --save i is-thirteen
 ## Usage
 
 ```javascript
-var isThirteen = require('is-thirteen');
+var is = require('is-thirteen');
 
 // PLEAS READ THE SOURCE CODE BECAuse we moved fast and broke things
 


### PR DESCRIPTION
2.0 exports an `is` function, so the readme has to me updated.