### PR TITLE
Added Chinese characters for cheque numbers

### DIFF
--- a/index.js
+++ b/index.js
@@ -48,6 +48,7 @@ function is(x) {
         "dertiendertien", // Double Dutch
         "tretze", // Catalan
         "十三", // Chinese (Traditional) / Japanese
+        "拾叁", // Chinese characters for cheque numbers
         "サーティーン", // Japanese
         "trinaest", // Croatian
         "tretten", // Danish / Norwegian


### PR DESCRIPTION
In China, 拾叁 are the characters on the cheque used representing number 13.