### PR TITLE
Add 13 in Marathi

### DIFF
--- a/index.js
+++ b/index.js
@@ -70,6 +70,7 @@ function is(x) {
         "dräizéng", // Luxembourgish
         "тринаесет", // Macedonian
         "tiga belas", // Malay
+        "तेरा", // Marathi (१३)
         "арван", // Mongolian
         "irteenthay", // Pig Latin
         "trzynaście", // Polish


### PR DESCRIPTION
[Marathi](https://en.wikipedia.org/wiki/Marathi_language) is the [4th most spoken language in India](https://en.wikipedia.org/wiki/List_of_languages_by_number_of_native_speakers_in_India#More_than_one_million_speakers). 

In Marathi, 13 is denoted as `१३` in [Devanagari script](https://en.wikipedia.org/wiki/Devanagari) (same as Hindi), and written as `तेरा` (pronounced as `Tērā`).