### PR TITLE
extend noop to reflect core competencies of the is-thirteen framework

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,8 +7,20 @@ var noop = require('noop3');
  * @returns {object}
  */
 function is(x) {
-    // this line calls the noop function
+    // this section calls the noop function 13 times
     noop();
+    noop();
+    noop();
+    noop();
+    noop();
+    noop();
+    noop();
+    noop();
+    noop();
+    noop();
+    noop();
+    noop();
+    noop();      
 
     var thirteenStrings = [
         '1101', // Binary 13


### PR DESCRIPTION
# Problem
 - There is 1 `noop()` call
 - The number `1` has no place other than the beginning of the number `13`
 - What were you guys thinking?

# Proposal:
 - Repeat the `noop()` 13 times, obviously.

# Discussion
This seems like a critical oversight. I mean, how do you guys call yourselves devs? This is basic stuff.