### PR TITLE
Extend the roughly thirteen with defining optional precision.

### DIFF
--- a/index.js
+++ b/index.js
@@ -108,6 +108,10 @@ function is(x) {
         "θərˈtiːn"
     ];
 
+    for (var i = 0; i < thirteenStrings.length; i++) {
+        thirteenStrings[i] = thirteenStrings[i].toLowerCase()
+    }
+
     if (thirteenStrings.indexOf(('' + x).toLowerCase()) > -1) {
         x = 13;
     }

--- a/index.js
+++ b/index.js
@@ -120,9 +120,12 @@ function is(x) {
         thirteen: function() {
             return x == 13;
         },
-        roughly: {
-            thirteen: function() {
-                return x >= 12.5 && x < 13.5;
+        roughly: function (delta) {
+            if (typeof delta == "undefined") delta = 0.5;
+            return {
+                thirteen: function() {
+                    return x >= 13 - delta && x < 13 + delta;
+                }
             }
         },
         not: {

--- a/test.js
+++ b/test.js
@@ -94,5 +94,6 @@ tap.equal(is("l3").thirteen(),true); //l3 looks like 13
 tap.equal(is("L3").thirteen(),true); //l3 looks like 13 when lower case
 tap.equal(is("|3").thirteen(),true); //|3 looks like 13
 
-
-
+// roughly
+tap.equal(is(12.9999).roughly(0.2).thirteen(), true);
+tap.equal(is(12.9999).roughly(0.000001).thirteen(), false);

--- a/test.js
+++ b/test.js
@@ -65,7 +65,7 @@ tap.equal(is("dräizéng").thirteen(), true); // Luxembourgish
 tap.equal(is("тринаесет").thirteen(), true); // Macedonian
 tap.equal(is("tiga belas").thirteen(), true); // Malay
 tap.equal(is("арван").thirteen(), true); // Mongolian
-tap.equal(is(".---- ...--").thirtees(), true); // Morse code
+tap.equal(is(".---- ...--").thirteen(), true); // Morse code
 tap.equal(is("irteenthay").thirteen(), true); // Pig Latin
 tap.equal(is("trzynaście").thirteen(), true); // Polish
 tap.equal(is("treze").thirteen(), true); // Portoguese


### PR DESCRIPTION
I believe that the is(value).roughly.thirteen() should be extended with optional precision. 

Ex.:
is(12.9).roughly(0.01).thirteen()
