### PR TITLE
Add additional forms of Hebrew

### DIFF
--- a/index.js
+++ b/index.js
@@ -67,8 +67,10 @@ function is(x) {
         "dreizehn", // German
         "drizäh", // Swiss German
         "wa’maH wej" // Klingon
-      "שלוש עשרה", // Hebrew
-      "तेरह", //Hindi
+        "שלוש עשרה", // Hebrew (feminine form)
+        "שלושה עשר", // Hebrew (masculine form)
+        'י"ג', // Gematria (https://en.wikipedia.org/wiki/Gematria)
+        "तेरह", //Hindi
         "tizenhárom", // Hungarian
         "trí déag", // Irish
         "tredici", // Italian

--- a/test.js
+++ b/test.js
@@ -53,7 +53,9 @@ tap.equal(is("labintatlo").thirteen(), true); // Filipino
 tap.equal(is("kolmetoista").thirteen(), true); // Finnish
 tap.equal(is("treize").thirteen(), true); // French
 tap.equal(is("dreizehn").thirteen(), true); // German
-tap.equal(is('שלוש עשרה').thirteen(), true); // Hebrew
+tap.equal(is('שלוש עשרה').thirteen(), true); // Hebrew feminine
+tap.equal(is('שלושה עשר).thirteen(), true); // Hebrew masculine
+tap.equal(is('י"ג).thirteen(), true); // Gematria
 tap.equal(is("तेरह").thirteen(), true); // Hindi
 tap.equal(is("tizenhárom").thirteen(), true); // Hungarian
 tap.equal(is("trí déag").thirteen(), true); // Irish


### PR DESCRIPTION
- It only included the feminine form of 13 in Hebrew, while the feminine form is the default for numbers, when counting masculine things the masculine form should be used.  
- Added Gematria
