### PR TITLE
Fixed Punjabi language 13

### DIFF
--- a/index.js
+++ b/index.js
@@ -87,7 +87,7 @@ function is(x) {
         "irteenthay", // Pig Latin
         "trzynaście", // Polish
         "treze", // Portuguese
-        "ਤੀਹ", // Punjabi
+        "ਤੇਰਾਂ", // Punjabi
         "treisprezece", // Romanian
         "тринадцать", // Russian
         "trinásť", // Slovak


### PR DESCRIPTION
Google translator is translating thirteen to "ਤੀਹ", which is 30 in Punjabi, not 13.
Correct word for thirteen in Punjabi is "ਤੇਰਾਂ".
Google translator is translating "ਤੇਰਾਂ" to "thirteen" correctly, but not vice versa.