### PR TITLE
Introduce coprime/relative integer

### DIFF
--- a/index.js
+++ b/index.js
@@ -150,6 +150,15 @@ function is(x) {
                 }
             }
         },
+        relatively: {
+            prime: {
+                to: {
+                    thirteen: function() {
+                        return x % 13 !== 0;
+                    }
+                }
+            }
+        },
         greater: {
             than: {
                 thirteen: function() {


### PR DESCRIPTION
Scientific background: https://en.wikipedia.org/wiki/Coprime_integers

In my humble opinion lack of such important function in this library is kind of misunderstanding. I cannot imagine how much frustration may it cause to current and future users. 

The reason I'm making such mind shortcut with this calculation is supported by studies that `13` is prime number so non-relative non-primes are only numbers that are multiplication of `thirteen`.

I hope this will help. 

Regards, Rafal