### PR TITLE
Allow alternative form of roman numerals

### DIFF
--- a/test.js
+++ b/test.js
@@ -9,6 +9,8 @@ tap.equal(is(1101).thirteen(), true);
 tap.equal(is('1101').thirteen(), true);
 tap.equal(is('XIII').thirteen(), true);
 tap.equal(is('xiii').thirteen(), true);
+tap.equal(is('IIIIIIIIIIIII').thirteen(), true); //Alternative form of roman numeral.
+tap.equal(is('IlIlIlIlIlIlI').thirteen(), true); //Looks like an alternative form for roman numeral.
 tap.equal(is('0xD').thirteen(), true);
 tap.equal(is('0xd').thirteen(), true);
 


### PR DESCRIPTION
While standard form for Roman numerals never have more than 3 characters of the same kind, It seems that that is just a preference and helps keep the number shorter. There aren't any requirements for the Roman numerals to actually follow such rules and the most common example is when old clocks have "IIII" instead of "IV" for 4.

For more information on this please take a look at https://en.wikipedia.org/wiki/Roman_numerals#Alternative_forms.