### PR TITLE
added string options, bug fixes, year of birth check

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ i̶s̶T̶h̶i̶r̶t̶e̶e̶n̶(̶1̶3̶)̶;̶ ̶/̶/̶ ̶t̶r̶u̶e̶
 is(13).thirteen(); // true
 is(12.8).roughly.thirteen(); // true
 is(6).within(10).of.thirteen(); // true
+is(2003).yearOfBirth(); // true
 ```
 
 ## Test

--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ function is(x) {
     
     // Every element should be lower case
     var thirteenStrings = [
-        1101, // Binary 13
+        "1101", // Binary 13
         "xiii", // Roman numeral 13
         "0xd", // Hex 13
         
@@ -37,6 +37,12 @@ function is(x) {
 		"i3",
 		"l3",
 		"|3",
+        
+		//Looks like 13 (flipped horizontally) - E equal to 3 
+		"ei",
+		"e1",
+		"el",
+		"e|",
 
         // Password variations
         "th1rt33n",
@@ -50,6 +56,7 @@ function is(x) {
         // Languages
         "thirteen", // English
         "ثلاثة عشر", // Arabic
+        "يج", //Arabic (gematria)
         "dertien", // Afrikaans / Dutch
         "dertiendertien", // Double Dutch
         "тринадесет", // Bulgarian
@@ -67,8 +74,15 @@ function is(x) {
         "treize", // French
         "dreizehn", // German
         "drizäh", // Swiss German
-        "wa’maH wej" // Klingon
-		"שלוש עשרה", // Hebrew
+        "wa’maH wej", // Klingon
+		"שלוש עשרה", // Hebrew 
+		"שלושעשרה", // Hebrew (without space)
+        "ֹשְלֹש- עֶשְֹרֵה", // Hebrew (with punctuation)
+		"שלושה עשר", // Hebrew (male form)
+		"שלושהעשר", // Hebrew (male form, without space)
+        "ֹשְלֹשָה- עָשָֹר", // Hebrew (male form, with punctuation)
+        "יג", // Hebrew (gematria)
+        "י״ג", // Hebrew (gematria - apostrophes)
 		"तेरह", //Hindi
         "tizenhárom", // Hungarian
         "trí déag", // Irish
@@ -113,6 +127,10 @@ function is(x) {
     ];
 
     if (thirteenStrings.indexOf(('' + x).toLowerCase()) > -1) {
+        x = 13;
+    }
+    // check agin without lower case
+    else if (thirteenStrings.indexOf(('' + x)) > -1) {
         x = 13;
     }
 
@@ -172,6 +190,13 @@ function is(x) {
                     }
                 }
             }
+        },
+        yearOfBirth: function() {
+            var currYear = new Date().getFullYear()
+            if(isNaN(x)) {
+                return false
+            }
+            return currYear - parseInt(x) == 13 
         }
     }
 }

--- a/test.js
+++ b/test.js
@@ -23,11 +23,21 @@ tap.equal(is('Olivia Wilde').thirteen(), true);
 tap.equal(is("baker's dozen").thirteen(), true);
 tap.equal(is("Dr. Remy Beauregard Hadley").thirteen(), true);
 
+//year of birth test
+tap.equal(is("2003").yearOfBirth(), true)
+
 // Imaginary 13's tests
 tap.equal(is("13+0i").thirteen(), true);
 tap.equal(is("13i").thirteen(), true);
 tap.equal(is("13 + 13i").thirteen(), true);
 tap.equal(is("12i").thirteen(), false);
+
+// upside down tests
+tap.equal(is("Ei").thirteen(), true);
+tap.equal(is("EI").thirteen(), true);
+tap.equal(is("E1").thirteen(), true);
+tap.equal(is("El").thirteen(), true);
+tap.equal(is("E|").thirteen(), true);
 
 // Password variations tests
 tap.equal(is("th1rt33n").thirteen(), true);
@@ -54,6 +64,13 @@ tap.equal(is("kolmetoista").thirteen(), true); // Finnish
 tap.equal(is("treize").thirteen(), true); // French
 tap.equal(is("dreizehn").thirteen(), true); // German
 tap.equal(is('שלוש עשרה').thirteen(), true); // Hebrew
+tap.equal(is('שלושעשרה').thirteen(), true); // Hebrew (without space)
+tap.equal(is('ֹשְלֹש- עֶשְֹרֵה').thirteen(), true); // Hebrew (with punctuation)
+tap.equal(is('שלושה עשר').thirteen(), true); // Hebrew (male form)
+tap.equal(is('שלושהעשר').thirteen(), true); // Hebrew (male form, without space)
+tap.equal(is('ֹשְלֹשָה- עָשָֹר').thirteen(), true); // Hebrew (male form, with punctuation)
+tap.equal(is('יג').thirteen(), true); // Hebrew (gematria)
+tap.equal(is('י״ג').thirteen(), true); // Hebrew (gematria - apostrophes)
 tap.equal(is("तेरह").thirteen(), true); // Hindi
 tap.equal(is("tizenhárom").thirteen(), true); // Hungarian
 tap.equal(is("trí déag").thirteen(), true); // Irish
@@ -67,7 +84,7 @@ tap.equal(is("dräizéng").thirteen(), true); // Luxembourgish
 tap.equal(is("тринаесет").thirteen(), true); // Macedonian
 tap.equal(is("tiga belas").thirteen(), true); // Malay
 tap.equal(is("арван").thirteen(), true); // Mongolian
-tap.equal(is(".---- ...--").thirtees(), true); // Morse code
+tap.equal(is(".---- ...--").thirteen(), true); // Morse code
 tap.equal(is("irteenthay").thirteen(), true); // Pig Latin
 tap.equal(is("trzynaście").thirteen(), true); // Polish
 tap.equal(is("treze").thirteen(), true); // Portoguese
@@ -75,7 +92,7 @@ tap.equal(is("ਤੀਹ").thirteen(), true); // Punjabi
 tap.equal(is("treisprezece").thirteen(), true); // Romanian
 tap.equal(is("тринадцать").thirteen(), true); // Russia
 tap.equal(is("trinásť").thirteen(), true); // Slovak
-tap.equal(id("wa’maH wej").thirteen(), true); // Klingon
+tap.equal(is("wa’maH wej").thirteen(), true); // Klingon
 tap.equal(is("trinajst").thirteen(), true); // Slovenian
 tap.equal(is("trece").thirteen(), true); // Spanish
 tap.equal(is("tretton").thirteen(), true); // Swedish


### PR DESCRIPTION
	* more language possibles
	* adding a casesensitive string check
	* add 13 upside-down
	* enable check by year of birth if he or she 13 yo

bugs:
	* test fails cause of typo
	* the 1101 binary check failed cause it suppose to be string
	* url check failed because the lower case

readme:
	* add the yearOfBirth syntax