### PR TITLE
Chaining math operations

### DIFF
--- a/is.js
+++ b/is.js
@@ -23,7 +23,7 @@ var is = function is(x) {
     // check agin without lower case
     else if (thirteenStrings.indexOf(('' + x)) > -1) {
         x = THIRTEEN;
-    } 
+    }
     else if( (typeof x) === "string" && /^[Il1]{13,13}$/.test(x) ) {
         x = THIRTEEN;
     }
@@ -51,7 +51,7 @@ var is = function is(x) {
         returning : {
             thirteen : function(){
                 return is(x()).thirteen();
-            } 
+            }
         },
         not: {
             thirteen: function() {
@@ -103,32 +103,16 @@ var is = function is(x) {
             return currYear - parseInt(x) == THIRTEEN
         },
         plus: function(y) {
-            return {
-                thirteen: function() {
-                    return x + y === THIRTEEN;
-                }
-            }
+            return is(x + y);
         },
         minus: function(y) {
-            return {
-                thirteen: function() {
-                    return x - y === THIRTEEN;
-                }
-            }
+            return is(x - y);
         },
         times: function(y) {
-            return {
-                thirteen: function() {
-                    return x * y === THIRTEEN;
-                }
-            }
+            return is(x * y);
         },
         dividedby: function(y) {
-          return {
-    	          thirteen: function(){
-                        return x/y === THIRTEEN;
-                }
-            }
+          return is(x / y);
         },
         canSpell: {
           thirteen: function(){

--- a/test.js
+++ b/test.js
@@ -140,6 +140,11 @@ tap.equal(is("Dilma").thirteen(), true); // Because the supreme Queen of Brazil 
 tap.equal(is(25).minus(12).thirteen(),true); // 25 - 12 === 13
 tap.equal(is(1).plus(12).thirteen(),true);   // 1  + 12 === 13
 
+tap.equal(is(2).times(8).plus(11).minus(1).dividedby(2).thirteen(), true) // (((2 * 8) + 11) - 1) / 2 === 13
+tap.equal(is(10).minus(1).plus(32).dividedby(4).times(3).thirteen(), false) // (((10 - 1) + 32) / 4) * 3 === 30.75
+
+tap.equal(is(5.3).plus(0.5).times(5).minus(4).dividedby(2).roughly.thirteen(), true) // (((12.5 * 2) + 4) / 5) - .5
+
 tap.equal(is(13).base(10).thirteen(), true);
 tap.equal(is(14).base(10).thirteen(), false);
 tap.equal(is("1101").base(2).thirteen(), true);


### PR DESCRIPTION
This commit allows you to chain math operations like so:

    is(5).plus(1).times(6).dividedby(2).minus(5).thirteen();  // (((5+1)*6)/2)-5 === 13

It also allows for residual operations against other methods like `not`, `roughly`, etc..

Unit tests included.