### PR TITLE
Fixed wrong language comment in test file

### DIFF
--- a/test.js
+++ b/test.js
@@ -85,7 +85,7 @@ tap.equal(is("तेरह").thirteen(), true); // Hindi
 tap.equal(is("tizenhárom").thirteen(), true); // Hungarian
 tap.equal(is("trí déag").thirteen(), true); // Irish
 tap.equal(is("tredici").thirteen(), true); // Italian
-tap.equal(is("on üç").thirteen(), true); // Italian
+tap.equal(is("on üç").thirteen(), true); // Turkish
 tap.equal(is("ಹದಿಮೂರು").thirteen(), true); //Kannada (thirteen)
 tap.equal(is("పదమూడు").thirteen(), true); //Telugu
 tap.equal(is("೧೩").thirteen(), true); //Kannada (13)


### PR DESCRIPTION
Fixed wrong language comment in test file: "on üç" is in Turkish.
https://translate.google.com.tr/#en/tr/thirteen