### PR TITLE
Add drei zehen; Fix tests

### DIFF
--- a/consts.js
+++ b/consts.js
@@ -24,6 +24,7 @@ var thirteenStrings = [
     "Washington Luís", // Brazil's thirteenth president
     "Millard Fillmore", // Thirteenth President of the United States
     "https://s3.amazonaws.com/rapgenius/calle13.jpg", // Calle 13, famous latin american band
+    "drei zehen", // German three toes
 
     "sharon carter", // Agent 13
 

--- a/test.js
+++ b/test.js
@@ -26,8 +26,9 @@ tap.equal(is("Patty Tsai").thirteen(), true);
 tap.equal(is("PT").thirteen(), true);
 tap.equal(is("Washington Luís").thirteen(), true);
 tap.equal(is("Millard Fillmore").thirteen(), true);
+tap.equal(is("drei zehen").thirteen(), true);
 //year of birth test
-tap.equal(is("2003").yearOfBirth(), true)
+tap.equal(is("2004").yearOfBirth(), true)
 
 // Imaginary 13's tests
 tap.equal(is("13+0i").thirteen(), true);


### PR DESCRIPTION
Three toes in German - Pronounced like the number "13"