### PR TITLE
Korean

### DIFF
--- a/consts.js
+++ b/consts.js
@@ -172,7 +172,7 @@ var thirteenStrings = [
     "ಹದಿಮೂರು", //Kannada (for thirteen)
     "೧೩",//Kannada (for 13)
     "열셋", // Korean
-	"십삼", // Korean
+	  "십삼", // Korean
     "sêzdeh", // Kurdish
     "tredecim", // Latin
     "trīspadsmit", // Latvian

--- a/consts.js
+++ b/consts.js
@@ -172,6 +172,7 @@ var thirteenStrings = [
     "ಹದಿಮೂರು", //Kannada (for thirteen)
     "೧೩",//Kannada (for 13)
     "열셋", // Korean
+	"십삼", // Korean
     "sêzdeh", // Kurdish
     "tredecim", // Latin
     "trīspadsmit", // Latvian

--- a/test.js
+++ b/test.js
@@ -90,6 +90,7 @@ tap.equal(is("ಹದಿಮೂರು").thirteen(), true); //Kannada (thirteen)
 tap.equal(is("పదమూడు").thirteen(), true); //Telugu
 tap.equal(is("೧೩").thirteen(), true); //Kannada (13)
 tap.equal(is("열셋").thirteen(), true); // Korean
+tap.equal(is("십삽").thirteen(), true); // Korean
 tap.equal(is("sêzdeh").thirteen(), true); // Kurdish
 tap.equal(is("tredecim").thirteen(), true); // Latin
 tap.equal(is("trīspadsmit").thirteen(), true); // Latvian


### PR DESCRIPTION
"십삽", another way of saying thirteen in Korean, is added in this commit. 
Reflected in const.js and test.js
