### PR TITLE
Add Aluminium (13th Element on Periodic Table) to 13 Constants

### DIFF
--- a/consts.js
+++ b/consts.js
@@ -28,6 +28,9 @@ var thirteenStrings = [
     "sharon carter", // Agent 13
 
     "weedle", //#13 Pokémon
+  
+    "aluminium", // thirteenth element
+    "AL", // thirteenth element abbreviation
 
     // Imaginary 13's
     "13+0i",

--- a/consts.js
+++ b/consts.js
@@ -30,7 +30,7 @@ var thirteenStrings = [
     "weedle", //#13 Pokémon
   
     "aluminium", // thirteenth element
-    "AL", // thirteenth element abbreviation
+    "al", // thirteenth element abbreviation
 
     // Imaginary 13's
     "13+0i",


### PR DESCRIPTION
Adds `"aluminium "` and `"al"` (periodic table symbol) to list of constants which are Thirteen