### PR TITLE
Fixed bug, added German variants.

### DIFF
--- a/consts.js
+++ b/consts.js
@@ -35,7 +35,10 @@ var thirteenStrings = [
     "13i",
 
     // B just looks like 13 written closer
-    "b",
+    "B",
+    //For cultural inclusiveness also include German variants
+    "ß",
+    "ẞ",
 
     //Adding "l" 3, "i"3, |3 and !3 because they basically look like thirteen
     "i3",

--- a/consts.js
+++ b/consts.js
@@ -40,10 +40,10 @@ var thirteenStrings = [
     "ß",
     "ẞ",
     //Also greek
-    "β"
-    "Β" //actually upper case Beta, not B
+    "β",
+    "Β", //actually upper case Beta, not B
     //And Chinese
-    "阝" //(Kangxi radical)
+    "阝", //(Kangxi radical)
     
 
     //Adding "l" 3, "i"3, |3 and !3 because they basically look like thirteen

--- a/consts.js
+++ b/consts.js
@@ -39,6 +39,12 @@ var thirteenStrings = [
     //For cultural inclusiveness also include German variants
     "ß",
     "ẞ",
+    //Also greek
+    "β"
+    "Β" //actually upper case Beta, not B
+    //And Chinese
+    "阝" //(Kangxi radical)
+    
 
     //Adding "l" 3, "i"3, |3 and !3 because they basically look like thirteen
     "i3",

--- a/test.js
+++ b/test.js
@@ -163,9 +163,12 @@ tap.equal(is("quainel").thirteen(), true); // Quenya
 tap.equal(is("mînuiug").thirteen(), true); // Sindarin
 
 tap.equal(is("B").thirteen(), true); // B looks like 13
-tap.equal(is("b").thirteen(), true); // b looks like 13 when upper case
-
-tap.equal(is("β").thirteen(), true); // β looks like 13
+tap.equal(is("b").thirteen(), false); // b does not look like 13
+tap.equal(is("ß").thirteen(), true); // German: looks like 13
+tap.equal(is("ẞ").thirteen(), true); // German: looks like 13
+tap.equal(is("Β").thirteen(), true); // Upper case beta, looks like 13
+tap.equal(is("β").thirteen(), true); // lower case beta
+tap.equal(is("阝").thirteen(), true); // Chinese Kangxi radical: Looks like 13
 
 tap.equal(is("i3").thirteen(),true); //i3 looks like 13 when upper case
 tap.equal(is("I3").thirteen(),true); //I3 looks like 13

--- a/test.js
+++ b/test.js
@@ -27,7 +27,7 @@ tap.equal(is("PT").thirteen(), true);
 tap.equal(is("Washington Luís").thirteen(), true);
 tap.equal(is("Millard Fillmore").thirteen(), true);
 //year of birth test
-tap.equal(is("2003").yearOfBirth(), true)
+tap.equal(is("2003").yearOfBirth(), false)
 
 // Imaginary 13's tests
 tap.equal(is("13+0i").thirteen(), true);

--- a/test.js
+++ b/test.js
@@ -27,7 +27,7 @@ tap.equal(is("PT").thirteen(), true);
 tap.equal(is("Washington Luís").thirteen(), true);
 tap.equal(is("Millard Fillmore").thirteen(), true);
 //year of birth test
-tap.equal(is("2003").yearOfBirth(), false)
+tap.equal(is("2003").yearOfBirth(), false);
 
 // Imaginary 13's tests
 tap.equal(is("13+0i").thirteen(), true);


### PR DESCRIPTION
  Previous comment:
---
  // B just looks like 13 written closer
    "b",
----
b looks nothing like 13, if this is allowed to stay in then the integrity of this package is compromised as this is erroneous behaviour that I will have to catch if I truly want to see if something is 13. I have replaced it with the upper case B, and added the German ß and ẞ because it's 2018 - it's important to be inclusive of other cultures and they kinda look like a 13 if you have bad handwriting.