### PR TITLE
 Add support for class (constructor) names

### DIFF
--- a/is.js
+++ b/is.js
@@ -33,6 +33,9 @@ var is = function is(x) {
              x = 13;
         }
     }
+    else if (is(x.constructor.name).thirteen()) {
+      x = THIRTEEN;
+    }
 
     return {
         thirteen: function() {

--- a/test.js
+++ b/test.js
@@ -204,3 +204,9 @@ tap.equal(is("oooooooooooooo").thirteen(), false);
 tap.equal(is("bbbbbbbbbbb").thirteen(), false);
 tap.equal(is("||h||||||||||").thirteen(), false);
 tap.equal(is("///i/////////").thirteen(), false);
+
+// Class tests
+class Thirteen{}
+class NotThirteen{}
+tap.equal(is(new Thirteen()).thirteen(), true);
+tap.equal(is(new NotThirteen()).thirteen(), false);

--- a/test.js
+++ b/test.js
@@ -206,7 +206,15 @@ tap.equal(is("||h||||||||||").thirteen(), false);
 tap.equal(is("///i/////////").thirteen(), false);
 
 // Class tests
-class Thirteen{}
-class NotThirteen{}
-tap.equal(is(new Thirteen()).thirteen(), true);
-tap.equal(is(new NotThirteen()).thirteen(), false);
+{ // ES5
+  function Thirteen(){}
+  function NotThirteen(){}
+  tap.equal(is(new Thirteen()).thirteen(), true);
+  tap.equal(is(new NotThirteen()).thirteen(), false);
+}
+{ // ES6
+  class Thirteen{}
+  class NotThirteen{}
+  tap.equal(is(new Thirteen()).thirteen(), true);
+  tap.equal(is(new NotThirteen()).thirteen(), false);
+}


### PR DESCRIPTION
It's 2018 and is-thirteen still doesn't support class/prototype names which are 13. This works for ES6 and in some cases for ES5, but shouldn't give any false positives for ES5.