### PR TITLE
Remove beta (duplicated)

### DIFF
--- a/consts.js
+++ b/consts.js
@@ -273,7 +273,6 @@ var thirteenStrings = [
     "तेह्र", //Nepali
     "१३", //Devanagari
     "तेरह", //Hindi
-    "β", //Think this is beta, which looks like a long 1 mashed together with a 3
     // Thirteen pronunciation
     "θərˈtiːn",
     "పదమూడు", //Telugu


### PR DESCRIPTION
I had previously pushed dc45975096eb4abc5488864302e4634c2c2f2ba3 which duplicated beta, as pointed out by @spazmodius, this patch fixes it.