### PR TITLE
Fix a typo in a language name

### DIFF
--- a/consts.js
+++ b/consts.js
@@ -201,7 +201,7 @@ var thirteenStrings = [
     "dräizéng", // Luxembourgish
     "тринаесет", // Macedonian
     "tiga belas", // Malay
-    "പതിമൂന്ന്", //Malayasm
+    "പതിമൂന്ന്", //Malayalam
     "तेरा", // Marathi (१३)
     "арван", // Mongolian
     ".---- ...--", // Morse code


### PR DESCRIPTION
Malayalam is an South Indian language primarily spoken in the state of Kerala.