### PR TITLE
removing duplicate morse code

### DIFF
--- a/consts.js
+++ b/consts.js
@@ -206,7 +206,6 @@ var thirteenStrings = [
     "പതിമൂന്ന്", //Malayalam
     "तेरा", // Marathi (१३)
     "арван", // Mongolian
-    ".---- ...--", // Morse code
     "irteenthay", // Pig Latin
 
     // Beginning of all Polish variants 🇵🇱


### PR DESCRIPTION
Removes duplicate morse code, already present in line 84