### PR TITLE
Add 13 in Sino-Vietnamese

### DIFF
--- a/consts.js
+++ b/consts.js
@@ -282,6 +282,7 @@ var thirteenStrings = [
     "тринадцять", // Ukrainian
     "تیرہ", // Urdu
     "mười ba", // Vietnamese
+    "thập tam", // Sino-Vietnamese
     "tri ar ddeg", // Welsh
     "דרייַצן", // Yiddish,
     "דרייצן", // Yiddish (without diacritics),


### PR DESCRIPTION
In Chinese `thập tam` is 十三 

`thập` = 10 
`tam` = 3

`thập tam` = 10 + 3 = 13