### PR TITLE
Add TypeScript definitions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,3 @@
+import is from "./is";
+
+export default is;

--- a/is.d.ts
+++ b/is.d.ts
@@ -1,0 +1,95 @@
+interface ThirteenMatcher {
+  thirteen(): boolean;
+  roughly: RoughlyThirteenMatcher;
+  returning: ReturningThirteenMatcher;
+  not: InvertedThirteenMatcher;
+  divisible: DivisibilityThirteenMatcher;
+  square: SquareThirteenMatcher;
+  greater: GreaterThirteenMatcher;
+  less: LessThirteenMatcher;
+  within(range: number): WithinThirteenMatcher;
+  yearOfBirth: YearOfBirthThirteenMatcher;
+  plus(amount: number): ThirteenMatcher;
+  minus(amount: number): ThirteenMatcher;
+  times(amount: number): ThirteenMatcher;
+  dividedBy(amount: number): ThirteenMatcher;
+  canSpell: CanSpellThirteenMatcher;
+  anagramOf: AnagramOfThirteenMatcher;
+  backwards: BackwardsThirteenMatcher;
+  atomicNumber: AtomicNumberThirteenMatcher;
+  base(x: number): BaseThirteenMatcher;
+}
+
+interface RoughlyThirteenMatcher {
+  thirteen(): boolean;
+}
+
+interface ReturningThirteenMatcher {
+  thirteen(): boolean;
+}
+
+interface InvertedThirteenMatcher {
+  thirteen(): boolean;
+}
+
+interface DivisibilityThirteenMatcher {
+  thirteen(): boolean;
+}
+
+interface SquareThirteenMatcher {
+  of: SquareOfThirteenMatcher;
+}
+
+interface SquareOfThirteenMatcher {
+  thirteen(): boolean;
+}
+
+interface GreaterThirteenMatcher {
+  than: GreaterThanThirteenMatcher;
+}
+
+interface GreaterThanThirteenMatcher {
+  thirteen(): boolean;
+}
+
+interface LessThirteenMatcher {
+  than: LessThanThirteenMatcher;
+}
+
+interface LessThanThirteenMatcher {
+  thirteen(): boolean;
+}
+
+interface WithinThirteenMatcher {
+  of: WithinOfThirteenMatcher;
+}
+
+interface WithinOfThirteenMatcher {
+  thirteen(): boolean;
+}
+
+interface YearOfBirthThirteenMatcher {
+  thirteen(): boolean;
+}
+
+interface CanSpellThirteenMatcher {
+  thirteen(): boolean;
+}
+
+interface AnagramOfThirteenMatcher {
+  thirteen(): boolean;
+}
+
+interface BackwardsThirteenMatcher {
+  thirteen(): boolean;
+}
+
+interface AtomicNumberThirteenMatcher {
+  thirteen(): boolean;
+}
+
+interface BaseThirteenMatcher {
+  thirteen(): boolean;
+}
+
+export default function is(n: any): ThirteenMatcher;


### PR DESCRIPTION
Hi there, I want to use _is-thirteen_ in my TypeScript project, but noticed that this package lacks type definitions. I've rectified that situation so you can be confident and type-safe while checking whether various things are or are not thirteen.