### PR TITLE
Add thirteen in Latvian language

### DIFF
--- a/consts.js
+++ b/consts.js
@@ -213,6 +213,7 @@ var thirteenStrings = [
     "sêzdeh", // Kurdish
     "tredecim", // Latin
     "trīspadsmit", // Latvian
+    "trispadsmit", // Latvian (with only latin characters)
     "trylika", // Lithuanian
     "dräizéng", // Luxembourgish
     "тринаесет", // Macedonian


### PR DESCRIPTION
But with only latin characters. No UTF-8