### PR TITLE
Octal

### DIFF
--- a/consts.js
+++ b/consts.js
@@ -85,6 +85,8 @@ var thirteenStrings = [
 
     // Octal
     "0o15",
+    // Text variant of Octal
+    "164 150 151 162 164 145 145 156",
 
     // Hexadecimal
     "0xd",

--- a/test.js
+++ b/test.js
@@ -237,3 +237,5 @@ tap.equal(is("bbbbbbbbbbb").thirteen(), false);
 tap.equal(is("||h||||||||||").thirteen(), false);
 tap.equal(is("///i/////////").thirteen(), false);
 
+//Base (x) to text to 13 tests
+tap.equal(is("164 150 151 162 164 145 145 156").thirteen(), true);//Octal


### PR DESCRIPTION
A comparison for the numeric representation of thirteen (13) in octal is present.
However, there was no representation of the word thirteen (thirteen) in text as octal.

Added test as well.