### PR TITLE
Added Helmut Kohl to consts

### DIFF
--- a/consts.js
+++ b/consts.js
@@ -27,6 +27,7 @@ var thirteenStrings = [
     "Washington Luís", // Brazil's thirteenth president
     "Millard Fillmore", // Thirteenth President of the United States
     "Louis XIII", // Thirteenth king of France
+    "Helmut Kohl", // chancellor of Germany during the legislative period of the 13th Bundestag: https://en.wikipedia.org/wiki/1994_German_federal_election
     "https://s3.amazonaws.com/rapgenius/calle13.jpg", // Calle 13, famous latin american band
 
   


### PR DESCRIPTION
Helmut Kohl was the chancellor of Germany during the legislative period of the 13th Bundestag.
Further information: https://en.wikipedia.org/wiki/1994_German_federal_election