### PR TITLE
Expand on Bulgarian entries & restructure contents

### DIFF
--- a/consts.js
+++ b/consts.js
@@ -148,8 +148,39 @@ var thirteenStrings = [
     "seriunteng",
     "serí-un-teng",
     "seríunteng",
-    "тринадесет", // Bulgarian
-    "тринайсет", // Also Bulgarian
+
+    // Beginning of all Bulgarian variants 🇧🇬
+    "тринадесет", // Official Bulgarian
+
+    "тринадесетте", // Plural form (base)
+    "тринадесетима", // Countable plural form (for people)
+    "тринадесетки", // Plural form (for pairs)
+
+    "тринадесети", // Action not being performed by the main subject (masculine)
+    "тринадесетия", // Action not being performed by the main subject (feminine)
+    "тринадесета", // Action not being performed by the main subject (gender neutral)
+    "тринадесето", // Action not being performed by the main subject (plural)
+    
+    "тринадесетият", // Action being performed by the main subject (masculine)
+    "тринадесетата", // Action being performed by the main subject (feminine)
+    "тринадесетото", // Action being performed by the main subject (gender neutral)
+    "тринадесетите", // Action being performed by the main subject (plural)
+
+    "тринайсет", // Bulgarian slang (still official)
+    
+    "тринайсетима", // Countable form
+    "тринайсетте", //  Countable form (again)
+
+    "тринайсети", //  Countable conjugation form (masculine + plural)
+    "тринайсетия", // Action not being performed by the main subject (masculine)
+    "тринайсета", //  Action not being performed by the main subject (feminine)
+    "тринайсето", //  Action not being perfomed by the main subject (gender neutral)
+
+    "тринайсетият", // Action being performed by the main subject (masculine)
+    "тринайсетата", // Action being performed by the main subject (feminine)
+    "тринайсетото", // Action being performed by the maub subject (gender neutral)
+    // End of all Bulgarian variants 🇧🇬
+
     "tretze", // Catalan
     "napulo ug tulo", // Cebuano
     "十三", // Chinese / Japanese


### PR DESCRIPTION
# Synopsis:
I have added additional forms of the word "thirteen" in Bulgarian, as well as a new structure for their organisation. 
### Structure:

1. Official base of the word

    - Countable / Plural form
    - Actions, that ***are not*** performed by the sentence's main subject (**masculine -> feminine -> gender neutral**)
    - Action that ***are*** performed by the sentence's main subject (**masculine -> feminine -> gender neutral**)
2. Official slang base of the word
    - Countable / Plural form
    - Actions, that ***are not*** performed by the sentence's main subject (**masculine -> feminine -> gender neutral**)
    - Action that ***are*** performed by the sentence's main subject (**masculine -> feminine -> gender neutral**)

(Every entry also has a commented clarification on what its' function is.)

## Free to discuss any suboptimal entries, if anything pops up. Have a nice day! :)