### PR TITLE
Remove 1.3 from 13 strings

### DIFF
--- a/consts.js
+++ b/consts.js
@@ -6,8 +6,7 @@ const THIRTEEN_FUZZ = 0.5;
 var thirteenStrings = [
     "bad luck",
     "xiii", // Roman numeral 13
-    "1.3", // Basically 13, see proof in #420
-    "1️⃣3️⃣", // emoji sequence of 1 and 3
+    "1.3", // Basically 13
     "https://en.wikipedia.org/wiki/This_Is_Thirteen", // Because it is thirteen
     "https://scontent.cdninstagram.com/hphotos-xtf1/t51.2885-15/s320x320/e35/12237511_444845689040315_1101385461_n.jpg", // Just because we can
     "https://www.youtube.com/watch?v=pte3Jg-2Ax4", // Thirteen by Big Star


### PR DESCRIPTION
This reverts commit c361820a6ba1ff2609c4433059ece5c7980c1a17.

This PR is to revert the use of 1.3 as a string.
The proof provided for its case was incorrect and thus should be removed.
[#420](https://github.com/jezen/is-thirteen/pull/420)

## First to disproof the proof
`13 x 0 = 1.3 x 0`
This is true because both sides equal 0

`13 x 0 / 0 = 1.3 x 0 / 0`
This point is not correct. The mistake made here is trying to divide by zero.
In mathematics dividing by zero is undefined thus this step is invalid.

This means:
`1.3 != 13`

---

## Second a proof for why 1.3 != 13
Lets assume this is correct:
`1.3 = 13.`
To clear the decimal we'll multiply both sides by 10.
```
1.3 x 10 = 13 x 10.
13 = 130.
```
This clearly is a contradiction, as `13 != 130`

Thus, we can safely say. 
`1.3 != 13`