### PR TITLE
update year of birth docs for 2025

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ const is = require('is-thirteen');
 is(13).thirteen(); // true
 is(12.8).roughly.thirteen(); // true
 is(6).within(10).of.thirteen(); // true
-is(2011).yearOfBirth(); // true
+is(2012).yearOfBirth(); // true
 
 // check your math skillz
 is(4).plus(5).thirteen();      // false


### PR DESCRIPTION
## Summary

This part of the readme is currently accurate but seems it will go out of date on January 1st, 2025. I am committing this approximately 13 days in advance to prepare for the new year.

This change should not be merged before the year 2025 begins. I would recommend merging on January 1st, perhaps sometime after the last time zone ticks to 00:01 (1 minute after midnight) on January 1st, 2025, this will help ensure that these docs do not result in any confusion prior to them becoming accurate.

## Testing

Please not that I have not tested/confirmed these changes locally, though I believe this example should be simple enough that manual testing is not necessary.