### PR TITLE
Add 13 in Kabyle to consts.json

### DIFF
--- a/consts.js
+++ b/consts.js
@@ -148,9 +148,9 @@ var thirteenStrings = [
     "سیزده", // Persian
     "۱۳", // Persian number
 
-    "ⵎⵔⴰⵡ ⴷ ⴽⵕⴰⴹ" // Kabyle (tifinagh literal form)
-    "ⵜⵍⴻⵟⵟⴰⵛ" // Kabyle (tifinagh)
-    "tleṭṭac" // Kabyle (romanized)
+    "ⵎⵔⴰⵡ ⴷ ⴽⵕⴰⴹ", // Kabyle (tifinagh literal form)
+    "ⵜⵍⴻⵟⵟⴰⵛ", // Kabyle (tifinagh)
+    "tleṭṭac", // Kabyle (romanized)
   
     "dertien", // Afrikaans / Dutch
     "dertiendertien", // Double Dutch

--- a/consts.js
+++ b/consts.js
@@ -148,6 +148,10 @@ var thirteenStrings = [
     "سیزده", // Persian
     "۱۳", // Persian number
 
+    "ⵎⵔⴰⵡ ⴷ ⴽⵕⴰⴹ" // Kabyle (tifinagh literal form)
+    "ⵜⵍⴻⵟⵟⴰⵛ" // Kabyle (tifinagh)
+    "tleṭṭac" // Kabyle (romanized)
+  
     "dertien", // Afrikaans / Dutch
     "dertiendertien", // Double Dutch
     "seri-un-teng", // Belter creole


### PR DESCRIPTION
Added 13 in the Kabyle language (including variations) of the berber region to improve accessibility for users and improve efficiency in checking for 13.